### PR TITLE
Added the port option to the config file

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,6 @@
 ---
+port: 8000
+
 database:
   name: f1db
   hostname: database

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -39,7 +39,7 @@ impl TryFrom<Config> for Api {
 
     fn try_from(config: Config) -> std::prelude::v1::Result<Self, Self::Error> {
         Ok(Self {
-            port: 8000,
+            port: config.port.unwrap_or(8000),
             router: router(&config)?,
         })
     }

--- a/crates/infrastructure/src/config.rs
+++ b/crates/infrastructure/src/config.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Config {
+    pub port: Option<u16>,
     pub database: DatabaseConfig,
     pub cache: DragonflyDBConfig,
     pub middlewares: Option<Vec<MiddlewareConfig>>,
@@ -13,7 +14,7 @@ impl Config {
     pub fn try_new() -> shared::error::Result<Self> {
         let config = Figment::from(Serialized::defaults(Config::default()))
             .merge(Yaml::file(
-                std::env::var("PURPLE_SECTOR_CONFIG").unwrap_or("config.yml".into()),
+                std::env::var("F1_API_CONFIG").unwrap_or("config.yml".into()),
             ))
             .extract()?;
         Ok(config)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added the port option to the config file

<!--- Describe your changes in detail -->

- added the port option to the config file

The config file scheme looks like this now

```yaml
---
port: 8000

database:
  name: f1db
  hostname: database
  port: 3306
  user: user
  password: password

cache:
  hostname: dragonfly
  port: 6379

middlewares:
  - graphiql:
      enabled: true
      route: /
```

## Related Issue

Issue #31 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)
